### PR TITLE
Add back urllib3 LICENSE.txt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ about:
     - LICENSE
     - THIRD_PARTY_NOTICES.md
     - newrelic/packages/wrapt/LICENSE
+    - newrelic/packages/urllib3/LICENSE.txt
   summary: New Relic Python Agent
   doc_url: https://docs.newrelic.com/docs/agents/python-agent
   description: |


### PR DESCRIPTION
Add back urllib3 LICENSE.txt file.
This was accidentally dropped in the last release but it has been added back into the repo for the next release so put this back into the recipe file.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
